### PR TITLE
Fix code scanning alert #8: Comparison of narrow type with wide type in loop condition

### DIFF
--- a/wolf3dredux_0.01/tools/wolfextractor/wolf/wolf_gfx.c
+++ b/wolf3dredux_0.01/tools/wolfextractor/wolf/wolf_gfx.c
@@ -880,7 +880,7 @@ PUBLIC void ReduxAlphaChannel_hq2x(W8 *data, W32 width, W32 height)
 */
 PRIVATE void SavePic(W32 chunknum, W16 version, W8 *buffer, W8 *buffer2)
 {
-    W16 i;
+    W32 i;
     W16 temp;
     char filename[32];
     char *fname;


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/Wolfenstein3DFromSource/security/code-scanning/8](https://github.com/cooljeanius/Wolfenstein3DFromSource/security/code-scanning/8)

_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
