### PR TITLE
Fix code scanning alert #11: Wrong type of arguments to formatting function

### DIFF
--- a/wolf3dredux_0.01/tools/wolfextractor/wolf/wolf_gfx.c
+++ b/wolf3dredux_0.01/tools/wolfextractor/wolf/wolf_gfx.c
@@ -1019,7 +1019,7 @@ STATUSBARHACK:
         ptr = (buffer + ((sx * 2) + (sy * width) * 2));
 
 		if (pic == NULL) {
-			printf("SavePic(): 'pic' is null, cannot use it to set 'temp' (in loop iteration '%i').\n", i);
+			printf("SavePic(): 'pic' is null, cannot use it to set 'temp' (in loop iteration '%lu').\n", i);
 			return;
 		} else {
 			temp = ((*pic) * 3);


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/Wolfenstein3DFromSource/security/code-scanning/11](https://github.com/cooljeanius/Wolfenstein3DFromSource/security/code-scanning/11)

_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
