### PR TITLE
Fix code scanning alert #5: Comparison of narrow type with wide type in loop condition

### DIFF
--- a/wolf3dredux_0.01/tools/wolfextractor/loaders/tga.c
+++ b/wolf3dredux_0.01/tools/wolfextractor/loaders/tga.c
@@ -143,7 +143,7 @@ PUBLIC W8 wolfextractor_WriteTGA(const char *filename, W16 bpp, W16 width,
 								 W16 height, void *Data, W8 upsideDown, W8 rle)
 #endif /* !WriteTGA */
 {
-    W16	i, x, y, BytesPerPixel;
+    W32	i, x, y, BytesPerPixel;
 	W8	*scanline;
 	W8 header[18];
 	FILE *filestream;


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/Wolfenstein3DFromSource/security/code-scanning/5](https://github.com/cooljeanius/Wolfenstein3DFromSource/security/code-scanning/5)

_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
