### PR TITLE
Fix code scanning alert #4: Comparison of narrow type with wide type in loop condition

### DIFF
--- a/wolf3dredux_0.01/tools/signon/WriteTGA_minimal.c
+++ b/wolf3dredux_0.01/tools/signon/WriteTGA_minimal.c
@@ -28,8 +28,8 @@ unsigned char WriteTGA(const char *filename, unsigned short bpp,
 					   unsigned short width, unsigned short height,
 					   void *Data, unsigned char upsideDown, unsigned char rle)
 {
-    unsigned short	i, y, BytesPerPixel;
-   unsigned int x;
+    unsigned short y, BytesPerPixel;
+    unsigned int i, x;
 	unsigned char *scanline = NULL;
 	unsigned char header[18];
 	FILE *filestream;

--- a/wolf3dredux_0.01/tools/signon/WriteTGA_minimal.c
+++ b/wolf3dredux_0.01/tools/signon/WriteTGA_minimal.c
@@ -28,7 +28,8 @@ unsigned char WriteTGA(const char *filename, unsigned short bpp,
 					   unsigned short width, unsigned short height,
 					   void *Data, unsigned char upsideDown, unsigned char rle)
 {
-    unsigned short	i, x, y, BytesPerPixel;
+    unsigned short	i, y, BytesPerPixel;
+   unsigned int x;
 	unsigned char *scanline = NULL;
 	unsigned char header[18];
 	FILE *filestream;


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/Wolfenstein3DFromSource/security/code-scanning/4](https://github.com/cooljeanius/Wolfenstein3DFromSource/security/code-scanning/4)

_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
