### PR TITLE
Fix code scanning alert #2: Comparison of narrow type with wide type in loop condition

### DIFF
--- a/wolf3dredux_0.01/loaders/tga.c
+++ b/wolf3dredux_0.01/loaders/tga.c
@@ -667,8 +667,8 @@ PUBLIC W8 loaders_WriteTGA(const char *filename, W16 bpp, W16 width, W16 height,
 						   void *Data, W8 upsideDown, W8 rle)
 #endif /* !WriteTGA */
 {
-    W16	i, y, BytesPerPixel;
-    int x;
+    W16 y, BytesPerPixel;
+    int i, x;
 	W8	*scanline;
 	W8 header[18];
 	FILE *filestream;

--- a/wolf3dredux_0.01/loaders/tga.c
+++ b/wolf3dredux_0.01/loaders/tga.c
@@ -667,7 +667,8 @@ PUBLIC W8 loaders_WriteTGA(const char *filename, W16 bpp, W16 width, W16 height,
 						   void *Data, W8 upsideDown, W8 rle)
 #endif /* !WriteTGA */
 {
-    W16	i, x, y, BytesPerPixel;
+    W16	i, y, BytesPerPixel;
+    int x;
 	W8	*scanline;
 	W8 header[18];
 	FILE *filestream;


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/Wolfenstein3DFromSource/security/code-scanning/2](https://github.com/cooljeanius/Wolfenstein3DFromSource/security/code-scanning/2)

_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
